### PR TITLE
WIP example capi

### DIFF
--- a/pkg/controllers/dashboard/controller.go
+++ b/pkg/controllers/dashboard/controller.go
@@ -2,7 +2,6 @@ package dashboard
 
 import (
 	"context"
-	"github.com/sirupsen/logrus"
 
 	"github.com/rancher/rancher/pkg/controllers/capr"
 	"github.com/rancher/rancher/pkg/controllers/dashboard/apiservice"
@@ -24,6 +23,7 @@ import (
 	"github.com/rancher/rancher/pkg/provisioningv2/kubeconfig"
 	"github.com/rancher/rancher/pkg/wrangler"
 	"github.com/rancher/wrangler/v3/pkg/needacert"
+	"github.com/sirupsen/logrus"
 )
 
 func Register(ctx context.Context, clients *wrangler.Context, embedded bool, registryOverride string) error {

--- a/pkg/rancher/migrations.go
+++ b/pkg/rancher/migrations.go
@@ -74,6 +74,14 @@ func runMigrations(wranglerContext *wrangler.Context) error {
 		}
 	}
 
+	if err := migrateImportedClusterFields(wranglerContext); err != nil {
+		return err
+	}
+
+	return rkeResourcesCleanup(wranglerContext)
+}
+
+func runRKE2Migrations(wranglerContext *wrangler.Context) error {
 	if features.RKE2.Enabled() {
 		// must migrate system agent data directory first, since update requests will be rejected by webhook if
 		// "CATTLE_AGENT_VAR_DIR" is set within AgentEnvVars.
@@ -90,12 +98,7 @@ func runMigrations(wranglerContext *wrangler.Context) error {
 			return err
 		}
 	}
-
-	if err := migrateImportedClusterFields(wranglerContext); err != nil {
-		return err
-	}
-
-	return rkeResourcesCleanup(wranglerContext)
+	return nil
 }
 
 func getConfigMap(configMapController controllerv1.ConfigMapController, configMapName string) (*v1.ConfigMap, error) {

--- a/pkg/rancher/rancher.go
+++ b/pkg/rancher/rancher.go
@@ -151,10 +151,6 @@ func New(ctx context.Context, clientConfg clientcmd.ClientConfig, opts *Options)
 		return nil, err
 	}
 
-	// back-fill the context with the CAPI factory when the relevant
-	// CRDs are available
-	go wranglerContext.ManageDeferredCAPIContext(ctx)
-
 	// Check for deprecated RKE1 resources in the cluster
 	if err := validateRKE1Resources(wranglerContext); err != nil {
 		return nil, fmt.Errorf("rke1 pre-upgrade validation failed: %w", err)

--- a/pkg/wrangler/capi.go
+++ b/pkg/wrangler/capi.go
@@ -20,13 +20,7 @@ func (w *Context) ManageDeferredCAPIContext(ctx context.Context) {
 	ticker := time.NewTicker(5 * time.Second)
 	defer ticker.Stop()
 
-	logrus.Infof("[deferred-capi - ManageDeferredCAPIContext] Starting to monitor CAPI CRD availability")
-
-	w.DeferredCAPIRegistration.mutex.Lock()
-	if w.DeferredCAPIRegistration.CAPIInitComplete {
-		return
-	}
-	w.DeferredCAPIRegistration.mutex.Unlock()
+	logrus.Info("[deferred-capi - ManageDeferredCAPIContext] Starting to monitor CAPI CRD availability")
 
 	for {
 		allCRDsReady := w.checkCAPICRDs()
@@ -96,7 +90,7 @@ func (w *Context) initializeCAPIFactory(ctx context.Context) {
 
 	capi, err := capi.NewFactoryFromConfigWithOptions(w.RESTConfig, opts)
 	if err != nil {
-		logrus.Fatalf("Encountered unexpected panic while creating capi factory: %v", err)
+		logrus.Fatalf("Encountered unexpected error while creating capi factory: %v", err)
 	}
 
 	w.DeferredCAPIRegistration.mutex.Lock()
@@ -114,7 +108,7 @@ func (w *Context) initializeCAPIFactory(ctx context.Context) {
 			logrus.Fatalf("Encountered unexpected error while invoking deferred pools: %v", err)
 		}
 		w.DeferredCAPIRegistration.CAPIInitComplete = true
-		logrus.Debugf("[deferred-capi - initializeCAPIFactory] Not starting controller factory as larger wrangler context has not yet started")
+		logrus.Debug("[deferred-capi - initializeCAPIFactory] Not starting controller factory as primary wrangler context has not yet started")
 		w.controllerLock.Unlock()
 		return
 	}
@@ -131,12 +125,13 @@ func (w *Context) initializeCAPIFactory(ctx context.Context) {
 		logrus.Fatalf("failed to invoke deferrred function pools")
 	}
 
-	logrus.Debugf("[deferred-capi - initializeCAPIFactory] Starting controller factory after initial wrangler start")
+	logrus.Debug("[deferred-capi - initializeCAPIFactory] Starting controller factory after initial wrangler start")
 	if err := w.ControllerFactory.Start(ctx, defaultControllerWorkerCount); err != nil {
 		logrus.Fatalf("Encountered unexpected error while starting capi factory: %v", err)
 	}
 
 	w.DeferredCAPIRegistration.CAPIInitComplete = true
+	logrus.Debug("[deferred-capi - initializeCAPIFactory] CAPI factory initialization complete")
 }
 
 type DeferredCAPIRegistration struct {
@@ -160,19 +155,19 @@ func (d *DeferredCAPIRegistration) CAPIInitialized() bool {
 // the lock on DeferredCAPIRegistration.mutex. Once all functions from both slices have been invoked, the
 // slices are reset.
 func (d *DeferredCAPIRegistration) invokePools(ctx context.Context, clients *Context) error {
-	logrus.Debugf("[deferred-capi - invokePools] Executing deferred registration function pool")
+	logrus.Debug("[deferred-capi - invokePools] Executing deferred registration function pool")
 	err := d.invokeRegistrationFuncs(ctx, clients, d.registrationFuncs)
 	if err != nil {
 		return err
 	}
-	logrus.Debugf("[deferred-capi - invokePools] deferred registration functions have completed")
+	logrus.Debug("[deferred-capi - invokePools] deferred registration functions have completed")
 
-	logrus.Debugf("[deferred-capi - invokePools] Executing deferred function pool")
+	logrus.Debug("[deferred-capi - invokePools] Executing deferred function pool")
 	for _, f := range d.funcs {
 		f(clients)
 		d.wg.Done()
 	}
-	logrus.Debugf("[deferred-capi - invokePools] deferred functions have completed")
+	logrus.Debug("[deferred-capi - invokePools] deferred functions have completed")
 
 	d.registrationFuncs = []func(ctx context.Context, clients *Context) error{}
 	d.funcs = []func(clients *Context){}
@@ -188,16 +183,16 @@ func (d *DeferredCAPIRegistration) DeferFunc(clients *Context, f func(clients *C
 	defer d.mutex.Unlock()
 
 	if d.CAPIInitComplete {
-		logrus.Debugf("[deferred-capi - DeferFunc] Executing deferred function as CAPI is initilized")
+		logrus.Debug("[deferred-capi - DeferFunc] Executing deferred function as CAPI is initialized")
 		defer func() {
-			logrus.Debugf("[deferred-capi - DeferFunc] deferred function has completed")
+			logrus.Debug("[deferred-capi - DeferFunc] deferred function has completed")
 		}()
 		f(clients)
 		return
 	}
 
 	d.wg.Add(1)
-	logrus.Debugf("[deferred-capi - DeferFunc] Adding function to pool")
+	logrus.Debug("[deferred-capi - DeferFunc] Adding function to pool")
 	d.funcs = append(d.funcs, f)
 }
 
@@ -207,9 +202,9 @@ func (d *DeferredCAPIRegistration) DeferFuncWithError(clients *Context, f func(w
 	errChan := make(chan error, 1)
 	go func(errs chan error) {
 		d.wg.Wait()
-		logrus.Debugf("[deferred-capi - DeferFuncWithError] Executing deferred function with error as CAPI is initilized")
+		logrus.Debug("[deferred-capi - DeferFuncWithError] Executing deferred function with error as CAPI is initialized")
 		defer func() {
-			logrus.Debugf("[deferred-capi - DeferFuncWithError] deferred function with error has completed")
+			logrus.Debug("[deferred-capi - DeferFuncWithError] deferred function with error has completed")
 		}()
 		err := f(clients)
 		defer close(errChan)
@@ -223,6 +218,7 @@ func (d *DeferredCAPIRegistration) DeferFuncWithError(clients *Context, f func(w
 
 // DeferRegistration enqueues a function to be executed once the CAPI CRDs are available by adding it to the registration function pool.
 // The functions passed to DeferRegistration are expected to register one or more event handlers which rely on CAPI clients.
+// Functions which must be deferred, but do not register event handlers, should be passed to DeferFunc instead.
 // Calls to DeferRegistration are processed in the order they are made. Calls to DeferRegistration made after the CAPI CRDs are
 // available will execute immediately, and the controller factory will be immediately started.
 func (d *DeferredCAPIRegistration) DeferRegistration(ctx context.Context, clients *Context, register func(ctx context.Context, clients *Context) error) error {
@@ -232,31 +228,36 @@ func (d *DeferredCAPIRegistration) DeferRegistration(ctx context.Context, client
 	d.wg.Add(1)
 
 	if d.CAPIInitComplete {
-		logrus.Debugf("[deferred-capi - DeferRegistration] Executing deferred registration function as CAPI is initilized")
+		logrus.Debug("[deferred-capi - DeferRegistration] Executing deferred registration function as CAPI is initialized")
 		defer func() {
-			logrus.Debugf("[deferred-capi - DeferRegistration] deferred registration function has completed")
+			logrus.Debug("[deferred-capi - DeferRegistration] deferred registration function has completed")
 		}()
 
-		clients.controllerLock.Lock()
-		wranglerStarted := clients.started
-		if !wranglerStarted {
-			logrus.Debugf("[deferred-capi - DeferRegistration] wrangler context has not yet started, will not start controller factory")
-			if err := d.invokeRegistrationFuncs(ctx, clients, []func(ctx context.Context, clients *Context) error{register}); err != nil {
+		invoke := func() (bool, error) {
+			clients.controllerLock.Lock()
+			defer clients.controllerLock.Unlock()
+			wranglerStarted := clients.started
+			if !wranglerStarted {
+				logrus.Debug("[deferred-capi - DeferRegistration] wrangler context has not yet started, will not start controller factory after registration")
+				return true, d.invokeRegistrationFuncs(ctx, clients, []func(ctx context.Context, clients *Context) error{register})
+			}
+			return false, nil
+		}
+
+		invoked, err := invoke()
+		if invoked {
+			if err != nil {
 				return err
 			}
 			return nil
 		}
-		clients.controllerLock.Unlock()
 
 		return clients.StartFactoryWithTransaction(ctx, func(ctx context.Context) error {
-			if err := d.invokeRegistrationFuncs(ctx, clients, []func(ctx context.Context, clients *Context) error{register}); err != nil {
-				return err
-			}
-			return nil
+			return d.invokeRegistrationFuncs(ctx, clients, []func(ctx context.Context, clients *Context) error{register})
 		})
 	}
 
-	logrus.Debugf("[deferred-capi - DeferRegistration] Adding registration function to pool")
+	logrus.Debug("[deferred-capi - DeferRegistration] Adding registration function to pool")
 	d.registrationFuncs = append(d.registrationFuncs, register)
 	return nil
 }

--- a/pkg/wrangler/capi.go
+++ b/pkg/wrangler/capi.go
@@ -2,44 +2,65 @@ package wrangler
 
 import (
 	"context"
+	"fmt"
 	"sync"
-	"time"
+	"sync/atomic"
 
 	capi "github.com/rancher/rancher/pkg/generated/controllers/cluster.x-k8s.io"
+	wapiextv1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/apiextensions.k8s.io/v1"
 	"github.com/rancher/wrangler/v3/pkg/generic"
 	"github.com/sirupsen/logrus"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // ManageDeferredCAPIContext polls for the availability of CAPI CRDs and registers deferred controllers
 // and executes deferred functions once they are available. Once CAPI CRDs are found, this function will
 // not continue polling. Individual registration calls can be made once polling is complete by directly using
 // the DeferredCAPIRegistration struct.
-func (w *Context) ManageDeferredCAPIContext(ctx context.Context) {
-	ticker := time.NewTicker(5 * time.Second)
-	defer ticker.Stop()
-
+func RegisterCAPICRDTracker(ctx context.Context, clients *Context) *DeferredCAPIRegistration {
 	logrus.Info("[deferred-capi - ManageDeferredCAPIContext] Starting to monitor CAPI CRD availability")
-
-	for {
-		allCRDsReady := w.checkCAPICRDs()
-		if allCRDsReady {
-			logrus.Debug("[deferred-capi - ManageDeferredCAPIContext] All CAPI CRDs are now available and established.")
-			w.initializeCAPIFactory(ctx)
-			return
+	var done atomic.Bool
+	capiReg := NewDeferredCAPIRegistration(clients)
+	clients.CRD.CustomResourceDefinition().OnChange(ctx, "capi-registration", func(key string, crd *apiextv1.CustomResourceDefinition) (*apiextv1.CustomResourceDefinition, error) {
+		if done.Load() {
+			return crd, nil
 		}
 
-		select {
-		case <-ctx.Done():
-			logrus.Error("[deferred-capi - ManageDeferredCAPIContext] Context cancelled while waiting for CAPI CRDs")
-			return
-		case <-ticker.C:
+		if !capiCRDsReady(clients.CRD.CustomResourceDefinition().Cache()) {
+			return crd, nil
 		}
-	}
+
+		if !done.CompareAndSwap(false, true) {
+			return crd, nil
+		}
+
+		logrus.Info("[deferred-capi - ManageDeferredCAPIContext] CAPI IS READY LETS GOO")
+		opts := &generic.FactoryOptions{
+			SharedControllerFactory: clients.ControllerFactory,
+		}
+
+		capi, err := capi.NewFactoryFromConfigWithOptions(clients.RESTConfig, opts)
+		if err != nil {
+			logrus.Fatalf("Encountered unexpected error while creating capi factory: %v", err)
+		}
+		capiReg.mutex.Lock()
+		defer capiReg.mutex.Unlock()
+
+		capiReg.CAPIInitComplete = true
+		clients.capi = capi
+		clients.CAPI = clients.capi.Cluster().V1beta1()
+
+		go func() {
+			capiReg.run(ctx)
+		}()
+
+		return crd, nil
+	})
+	return capiReg
 }
 
-func (w *Context) checkCAPICRDs() bool {
+func capiCRDsReady(crdCache wapiextv1.CustomResourceDefinitionCache) bool {
 	requiredCRDs := []string{
 		"clusters.cluster.x-k8s.io",
 		"machines.cluster.x-k8s.io",
@@ -51,7 +72,7 @@ func (w *Context) checkCAPICRDs() bool {
 	logrus.Debug("[deferred-capi] Checking CAPI CRDs availability and establishment status")
 	allCRDsReady := true
 	for _, crdName := range requiredCRDs {
-		crd, err := w.CRD.CustomResourceDefinition().Get(crdName, metav1.GetOptions{})
+		crd, err := crdCache.Get(crdName)
 		if err != nil {
 			if errors.IsNotFound(err) {
 				logrus.Debugf("[deferred-capi] CRD %s not found, continuing to wait", crdName)
@@ -83,65 +104,44 @@ func (w *Context) checkCAPICRDs() bool {
 	return allCRDsReady
 }
 
-func (w *Context) initializeCAPIFactory(ctx context.Context) {
-	opts := &generic.FactoryOptions{
-		SharedControllerFactory: w.ControllerFactory,
-	}
-
-	capi, err := capi.NewFactoryFromConfigWithOptions(w.RESTConfig, opts)
-	if err != nil {
-		logrus.Fatalf("Encountered unexpected error while creating capi factory: %v", err)
-	}
-
-	w.DeferredCAPIRegistration.mutex.Lock()
-	defer w.DeferredCAPIRegistration.mutex.Unlock()
-
-	w.capi = capi
-	w.CAPI = w.capi.Cluster().V1beta1()
-
-	// If the larger wrangler context has not started yet, do not start it prematurely
-	w.controllerLock.Lock()
-	wranglerHasStarted := w.started
-	if !wranglerHasStarted {
-		err = w.DeferredCAPIRegistration.invokePools(ctx, w)
-		if err != nil {
-			logrus.Fatalf("Encountered unexpected error while invoking deferred pools: %v", err)
-		}
-		w.DeferredCAPIRegistration.CAPIInitComplete = true
-		logrus.Debug("[deferred-capi - initializeCAPIFactory] Not starting controller factory as primary wrangler context has not yet started")
-		w.controllerLock.Unlock()
-		return
-	}
-	w.controllerLock.Unlock()
-
-	// If wrangler has already started, start the factory again to pick up new registrations
-	if err := w.StartFactoryWithTransaction(ctx, func(ctx context.Context) error {
-		err = w.DeferredCAPIRegistration.invokePools(ctx, w)
-		if err != nil {
-			logrus.Fatalf("Encountered unexpected error while invoking deferred pools: %v", err)
-		}
-		return nil
-	}); err != nil {
-		logrus.Fatalf("failed to invoke deferrred function pools")
-	}
-
-	logrus.Debug("[deferred-capi - initializeCAPIFactory] Starting controller factory after initial wrangler start")
-	if err := w.ControllerFactory.Start(ctx, defaultControllerWorkerCount); err != nil {
-		logrus.Fatalf("Encountered unexpected error while starting capi factory: %v", err)
-	}
-
-	w.DeferredCAPIRegistration.CAPIInitComplete = true
-	logrus.Debug("[deferred-capi - initializeCAPIFactory] CAPI factory initialization complete")
-}
-
 type DeferredCAPIRegistration struct {
 	CAPIInitComplete bool
 
 	wg    *sync.WaitGroup
 	mutex sync.Mutex
 
-	registrationFuncs []func(ctx context.Context, clients *Context) error
-	funcs             []func(clients *Context)
+	clients           *Context
+	registrationFuncs chan func(ctx context.Context, clients *Context) error
+	funcs             chan func(clients *Context)
+}
+
+func NewDeferredCAPIRegistration(clients *Context) *DeferredCAPIRegistration {
+	return &DeferredCAPIRegistration{
+		clients:           clients,
+		registrationFuncs: make(chan func(ctx context.Context, clients *Context) error, 100),
+		funcs:             make(chan func(clients *Context), 100),
+	}
+}
+
+func (d *DeferredCAPIRegistration) run(ctx context.Context) error {
+	for {
+		select {
+		case f := <-d.registrationFuncs:
+			if err := d.clients.StartFactoryWithTransaction(ctx, func(ctx context.Context) error {
+				if err := f(ctx, d.clients); err != nil {
+					return fmt.Errorf("reg func: %w", err)
+				}
+				return nil
+			}); err != nil {
+				return err
+			}
+		case f := <-d.funcs:
+			f(d.clients)
+		case <-ctx.Done():
+			return nil
+		}
+
+	}
 }
 
 func (d *DeferredCAPIRegistration) CAPIInitialized() bool {
@@ -150,69 +150,25 @@ func (d *DeferredCAPIRegistration) CAPIInitialized() bool {
 	return d.CAPIInitComplete
 }
 
-// invokePools sequentially executes all functions pooled within the DeferredCAPIRegistration.registrationFuncs and
-// DeferredCAPIRegistration.funcs slices, in that order. The caller of invokePools must first acquire
-// the lock on DeferredCAPIRegistration.mutex. Once all functions from both slices have been invoked, the
-// slices are reset.
-func (d *DeferredCAPIRegistration) invokePools(ctx context.Context, clients *Context) error {
-	logrus.Debug("[deferred-capi - invokePools] Executing deferred registration function pool")
-	err := d.invokeRegistrationFuncs(ctx, clients, d.registrationFuncs)
-	if err != nil {
-		return err
-	}
-	logrus.Debug("[deferred-capi - invokePools] deferred registration functions have completed")
-
-	logrus.Debug("[deferred-capi - invokePools] Executing deferred function pool")
-	for _, f := range d.funcs {
-		f(clients)
-		d.wg.Done()
-	}
-	logrus.Debug("[deferred-capi - invokePools] deferred functions have completed")
-
-	d.registrationFuncs = []func(ctx context.Context, clients *Context) error{}
-	d.funcs = []func(clients *Context){}
-
-	return nil
-}
-
 // DeferFunc enqueues a function to be executed once the CAPI CRDs are available by adding it to the function pool.
 // Calls to DeferFunc are processed in the order they are made. Calls to DeferFunc made after the CAPI CRDs are
 // available will execute immediately.
 func (d *DeferredCAPIRegistration) DeferFunc(clients *Context, f func(clients *Context)) {
-	d.mutex.Lock()
-	defer d.mutex.Unlock()
-
-	if d.CAPIInitComplete {
-		logrus.Debug("[deferred-capi - DeferFunc] Executing deferred function as CAPI is initialized")
-		defer func() {
-			logrus.Debug("[deferred-capi - DeferFunc] deferred function has completed")
-		}()
-		f(clients)
-		return
-	}
-
-	d.wg.Add(1)
 	logrus.Debug("[deferred-capi - DeferFunc] Adding function to pool")
-	d.funcs = append(d.funcs, f)
+	d.funcs <- f
 }
 
 // DeferFuncWithError creates a new go routine which invokes f once the DeferredCAPIRegistration wait group completes.
 // It returns an error channel to indicate if f encountered any errors during execution.
 func (d *DeferredCAPIRegistration) DeferFuncWithError(clients *Context, f func(wrangler *Context) error) chan error {
 	errChan := make(chan error, 1)
-	go func(errs chan error) {
-		d.wg.Wait()
-		logrus.Debug("[deferred-capi - DeferFuncWithError] Executing deferred function with error as CAPI is initialized")
-		defer func() {
-			logrus.Debug("[deferred-capi - DeferFuncWithError] deferred function with error has completed")
-		}()
-		err := f(clients)
+	d.funcs <- func(clients *Context) {
 		defer close(errChan)
 
-		if err != nil {
+		if err := f(clients); err != nil {
 			errChan <- err
 		}
-	}(errChan)
+	}
 	return errChan
 }
 
@@ -222,52 +178,7 @@ func (d *DeferredCAPIRegistration) DeferFuncWithError(clients *Context, f func(w
 // Calls to DeferRegistration are processed in the order they are made. Calls to DeferRegistration made after the CAPI CRDs are
 // available will execute immediately, and the controller factory will be immediately started.
 func (d *DeferredCAPIRegistration) DeferRegistration(ctx context.Context, clients *Context, register func(ctx context.Context, clients *Context) error) error {
-	d.mutex.Lock()
-	defer d.mutex.Unlock()
-
-	d.wg.Add(1)
-
-	if d.CAPIInitComplete {
-		logrus.Debug("[deferred-capi - DeferRegistration] Executing deferred registration function as CAPI is initialized")
-		defer func() {
-			logrus.Debug("[deferred-capi - DeferRegistration] deferred registration function has completed")
-		}()
-
-		invoke := func() (bool, error) {
-			clients.controllerLock.Lock()
-			defer clients.controllerLock.Unlock()
-			wranglerStarted := clients.started
-			if !wranglerStarted {
-				logrus.Debug("[deferred-capi - DeferRegistration] wrangler context has not yet started, will not start controller factory after registration")
-				return true, d.invokeRegistrationFuncs(ctx, clients, []func(ctx context.Context, clients *Context) error{register})
-			}
-			return false, nil
-		}
-
-		invoked, err := invoke()
-		if invoked {
-			if err != nil {
-				return err
-			}
-			return nil
-		}
-
-		return clients.StartFactoryWithTransaction(ctx, func(ctx context.Context) error {
-			return d.invokeRegistrationFuncs(ctx, clients, []func(ctx context.Context, clients *Context) error{register})
-		})
-	}
-
 	logrus.Debug("[deferred-capi - DeferRegistration] Adding registration function to pool")
-	d.registrationFuncs = append(d.registrationFuncs, register)
-	return nil
-}
-
-func (d *DeferredCAPIRegistration) invokeRegistrationFuncs(transaction context.Context, clients *Context, f []func(ctx context.Context, clients *Context) error) error {
-	for _, register := range f {
-		if err := register(transaction, clients); err != nil {
-			return err
-		}
-		d.wg.Done()
-	}
+	d.registrationFuncs <- register
 	return nil
 }

--- a/pkg/wrangler/context.go
+++ b/pkg/wrangler/context.go
@@ -297,7 +297,7 @@ func (w *Context) WithAgent(userAgent string) *Context {
 		wContextCopy.CAPI = wContextCopy.capi.WithAgent(userAgent).V1beta1()
 	} else {
 		wContextCopy.DeferredCAPIRegistration.DeferFunc(&wContextCopy, func(clients *Context) {
-			wContextCopy.CAPI = clients.capi.WithAgent(userAgent).V1beta1()
+			wContextCopy.CAPI = wContextCopy.capi.WithAgent(userAgent).V1beta1()
 		})
 	}
 

--- a/pkg/wrangler/context.go
+++ b/pkg/wrangler/context.go
@@ -9,7 +9,6 @@ import (
 	"net"
 	"net/http"
 	"sync"
-	"time"
 
 	fleetv1alpha1api "github.com/rancher/fleet/pkg/apis/fleet.cattle.io/v1alpha1"
 	"github.com/rancher/lasso/pkg/controller"
@@ -105,6 +104,8 @@ var (
 	AddToScheme = localSchemeBuilder.AddToScheme
 	Scheme      = runtime.NewScheme()
 )
+
+const defaultControllerWorkerCount = 50
 
 func init() {
 	metav1.AddToGroupVersion(Scheme, schema.GroupVersion{Version: "v1"})
@@ -206,7 +207,7 @@ func (w *Context) StartWithTransaction(ctx context.Context, f func(context.Conte
 	return w.Start(ctx)
 }
 
-func (w *Context) StartSharedFactoryWithTransaction(ctx context.Context, f func(context.Context) error) (err error) {
+func (w *Context) StartFactoryWithTransaction(ctx context.Context, f func(context.Context) error) (err error) {
 	w.controllerLock.Lock()
 	defer w.controllerLock.Unlock()
 
@@ -225,7 +226,7 @@ func (w *Context) StartSharedFactoryWithTransaction(ctx context.Context, f func(
 	w.ControllerFactory.SharedCacheFactory().WaitForCacheSync(ctx)
 	transaction.Commit()
 
-	if err := w.ControllerFactory.Start(ctx, 50); err != nil {
+	if err := w.ControllerFactory.Start(ctx, defaultControllerWorkerCount); err != nil {
 		return err
 	}
 
@@ -244,10 +245,11 @@ func (w *Context) Start(ctx context.Context) error {
 		w.started = true
 	}
 
-	if err := w.ControllerFactory.Start(ctx, 50); err != nil {
+	if err := w.ControllerFactory.Start(ctx, defaultControllerWorkerCount); err != nil {
 		return err
 	}
 	w.leadership.Start(ctx)
+	logrus.Trace("Wrangler context has started")
 	return nil
 }
 
@@ -290,29 +292,16 @@ func (w *Context) WithAgent(userAgent string) *Context {
 	wContextCopy.API = wContextCopy.api.WithAgent(userAgent).V1()
 	wContextCopy.CRD = wContextCopy.crd.WithAgent(userAgent).V1()
 	wContextCopy.Plan = wContextCopy.plan.WithAgent(userAgent).V1()
-	if w.DeferredCAPIRegistration.CAPIInitialized {
+
+	if w.DeferredCAPIRegistration.CAPIInitialized() {
 		wContextCopy.CAPI = wContextCopy.capi.WithAgent(userAgent).V1beta1()
 	} else {
-		go wContextCopy.BackfillCAPI(&wContextCopy)
+		wContextCopy.DeferredCAPIRegistration.DeferFunc(&wContextCopy, func(clients *Context) {
+			wContextCopy.CAPI = clients.capi.WithAgent(userAgent).V1beta1()
+		})
 	}
 
 	return &wContextCopy
-}
-
-func (w *Context) BackfillCAPI(cpy *Context) {
-	printCapi := false
-	for {
-		if w.DeferredCAPIRegistration.CAPIInitialized {
-			if printCapi {
-				logrus.Trace("CAPI was initialized, retroactively adding to copy")
-			}
-			w.CAPI = cpy.CAPI
-			return
-		}
-		printCapi = true
-		logrus.Trace("Waiting for CAPI to be initialized before populating CAPI clients in copy")
-		time.Sleep(time.Second * 2)
-	}
 }
 
 func enableProtobuf(cfg *rest.Config) *rest.Config {
@@ -527,14 +516,9 @@ func NewContext(ctx context.Context, clientConfig clientcmd.ClientConfig, restCo
 		telemetry:    telemetry,
 
 		DeferredCAPIRegistration: &DeferredCAPIRegistration{
-			wg:              &sync.WaitGroup{},
-			CAPIInitialized: false,
+			wg: &sync.WaitGroup{},
 		},
 	}
-
-	// back-fill the context with the CAPI factory when the relevant
-	// CRDs are available
-	go wContext.ManageDeferredCAPIContext(ctx)
 
 	return wContext, nil
 }

--- a/tests/v2prov/clients/clients.go
+++ b/tests/v2prov/clients/clients.go
@@ -4,9 +4,13 @@ import (
 	"context"
 	"time"
 
+	capi "github.com/rancher/rancher/pkg/generated/controllers/cluster.x-k8s.io"
+	capicontrollers "github.com/rancher/rancher/pkg/generated/controllers/cluster.x-k8s.io/v1beta1"
 	"github.com/rancher/rancher/pkg/wrangler"
+	"github.com/rancher/wrangler/v3/pkg/generic"
 	"github.com/rancher/wrangler/v3/pkg/kubeconfig"
 	"github.com/rancher/wrangler/v3/pkg/ratelimit"
+	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/tools/clientcmd"
@@ -15,6 +19,9 @@ import (
 type Clients struct {
 	*wrangler.Context
 	Dynamic dynamic.Interface
+
+	capi *capi.Factory
+	CAPI capicontrollers.Interface
 
 	// Ctx is canceled when the Close() is called
 	Ctx     context.Context
@@ -70,6 +77,16 @@ func NewForConfig(ctx context.Context, config clientcmd.ClientConfig) (*Clients,
 		return nil, err
 	}
 
+	// CAPI CRDs are a prerequisite to running prov v2 tests
+	opts := &generic.FactoryOptions{
+		SharedControllerFactory: wranglerCtx.ControllerFactory,
+	}
+
+	capi, err := capi.NewFactoryFromConfigWithOptions(wranglerCtx.RESTConfig, opts)
+	if err != nil {
+		logrus.Fatalf("Encountered unexpected panic while creating capi factory: %v", err)
+	}
+
 	dynamic, err := dynamic.NewForConfig(rest)
 	if err != nil {
 		cancel()
@@ -79,7 +96,11 @@ func NewForConfig(ctx context.Context, config clientcmd.ClientConfig) (*Clients,
 	return &Clients{
 		Context: wranglerCtx,
 		Dynamic: dynamic,
-		Ctx:     ctx,
-		cancel:  cancel,
+
+		capi: capi,
+		CAPI: capi.Cluster().V1beta1(),
+
+		Ctx:    ctx,
+		cancel: cancel,
 	}, nil
 }


### PR DESCRIPTION
StartFactoryWithTransaction could still block the defer calls. So instead.. How about move that startWith.. in a separate goroutine. All defer calls basically just adds a function to a channel.

We get:
- no blocking
- no need for `if capi initialize then invoke` logic spread out

What the PR is doing is:
- Modify (ugly but can be cleaned up) wrangler.New to start CRD controllers right away
- Register a OnChange CRD handler to initialize capi (no polling anymore) and doesn't go to k8s
- Start a goroutine to run the deferred func once CAPI is initialized